### PR TITLE
refactor: move tm client default parameters

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,12 +18,6 @@ import (
 	"github.com/axelarnetwork/tm-events/tendermint"
 )
 
-// default flag values
-const (
-	DefaultWSEndpoint = "/websocket"
-	DefaultAddress    = "http://localhost:26657"
-)
-
 func main() {
 	var (
 		rpcURL   string
@@ -49,8 +43,8 @@ func main() {
 		},
 	}
 
-	cmd.PersistentFlags().StringVar(&rpcURL, "address", DefaultAddress, "tendermint RPC address")
-	cmd.PersistentFlags().StringVar(&endpoint, "endpoint", DefaultWSEndpoint, "websocket endpoint")
+	cmd.PersistentFlags().StringVar(&rpcURL, "address", tendermint.DefaultAddress, "tendermint RPC address")
+	cmd.PersistentFlags().StringVar(&endpoint, "endpoint", tendermint.DefaultWSEndpoint, "websocket endpoint")
 
 	cmd.AddCommand(
 		CmdWaitEvent(&eventBus, logger),

--- a/tendermint/client.go
+++ b/tendermint/client.go
@@ -9,6 +9,12 @@ import (
 	tmClient "github.com/tendermint/tendermint/rpc/client/http"
 )
 
+// default client parameters
+const (
+	DefaultWSEndpoint = "/websocket"
+	DefaultAddress    = "http://localhost:26657"
+)
+
 // StartClient connects a client to the given tendermint endpoint
 func StartClient(address string, endpoint string, logger tmlog.Logger) (client.Client, error) {
 	if !validEndpoint(endpoint) {


### PR DESCRIPTION
## Description
The default parameters are used in other repos, so it makes more sense to move them close to the client instead of leaving them in the cmds module
