### PR TITLE
feat: add explicit back-off option to notifier

### DIFF
--- a/events/source.go
+++ b/events/source.go
@@ -95,10 +95,10 @@ func newEventBlockNotifier(client SubscriptionClient, logger log.Logger, options
 		opts = option.apply(opts)
 	}
 	return &eventblockNotifier{
-		client: client,
-		logger: logger,
-		query:  query.MustParse(fmt.Sprintf("%s='%s'", tm.EventTypeKey, tm.EventNewBlockHeader)).String(),
-
+		client:            client,
+		logger:            logger,
+		query:             query.MustParse(fmt.Sprintf("%s='%s'", tm.EventTypeKey, tm.EventNewBlockHeader)).String(),
+		backOff:           opts.backOff,
 		timeout:           opts.timeout,
 		retries:           opts.retries,
 		keepAliveInterval: opts.keepAlive,

--- a/events/source.go
+++ b/events/source.go
@@ -162,7 +162,7 @@ func (b *eventblockNotifier) BlockHeights(ctx context.Context) (<-chan int64, <-
 }
 
 func (b *eventblockNotifier) subscribe(ctx context.Context) (<-chan coretypes.ResultEvent, error) {
-	nextBackOff := utils.LinearBackOff(b.backOff)
+	backOff := utils.LinearBackOff(b.backOff)
 	for i := 0; i <= b.retries; i++ {
 		ctx, cancel := ctxWithTimeout(ctx, b.timeout)
 		eventChan, err := b.client.Subscribe(ctx, "", b.query, WebsocketQueueSize)
@@ -172,7 +172,7 @@ func (b *eventblockNotifier) subscribe(ctx context.Context) (<-chan coretypes.Re
 			return eventChan, nil
 		}
 		b.logger.Debug(sdkerrors.Wrapf(err, "failed to subscribe to query \"%s\", attempt %d", b.query, i+1).Error())
-		time.Sleep(nextBackOff(i))
+		time.Sleep(backOff(i))
 	}
 	return nil, fmt.Errorf("aborting Tendermint block header subscription after %d attemts ", b.retries+1)
 }


### PR DESCRIPTION
## Description

Previously, back-off could not be configured independently from the query request timeout.


## Todos

- [x] Unit tests
- [ ] Manual tests
- [x] Documentation
- [x] Connect epics/issues
- [x] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
