### PR TITLE
fix(eventBus): retried requests do not re-establish the tendermint client connection

### DIFF
--- a/events/source.go
+++ b/events/source.go
@@ -331,7 +331,7 @@ func NewBlockNotifier(client BlockClient, logger log.Logger, options ...DialOpti
 }
 
 // StartingAt sets the start block from which to receive notifications
-func (b *Notifier) StartingAt(block int64) Notifier {
+func (b *Notifier) StartingAt(block int64) *Notifier {
 	if block > 0 {
 		b.start = block
 	}

--- a/events/source.go
+++ b/events/source.go
@@ -359,7 +359,16 @@ func (b *Notifier) Done() <-chan struct{} {
 }
 
 // NewBlockNotifier returns a new BlockNotifier instance
-func NewBlockNotifier(getClient BlockClientFactory, logger log.Logger, options ...DialOption) *Notifier {
+// NewBlockNotifier maintains compatibility with vald
+func NewBlockNotifier(client BlockClient, logger log.Logger, options ...DialOption) *Notifier {
+	getClient := func() (BlockClient, error) {
+		return client, nil
+	}
+	return NewBlockNotifierWithClient(getClient, logger, options...)
+}
+
+// NewBlockNotifierWithClient returns a new BlockNotifier instance
+func NewBlockNotifierWithClient(getClient BlockClientFactory, logger log.Logger, options ...DialOption) *Notifier {
 	var opts dialOptions
 	for _, option := range options {
 		opts = option.apply(opts)

--- a/events/source.go
+++ b/events/source.go
@@ -514,12 +514,17 @@ type BlockResultClient interface {
 
 // NewBlockSource returns a new BlockSource instance
 // NewBlockSource maintains compatibility with vald
-func NewBlockSource(client BlockResultClient, notifier BlockNotifier, timeout time.Duration) BlockSource {
+func NewBlockSource(client BlockResultClient, notifier BlockNotifier, timeout ...time.Duration) BlockSource {
 	getClient := func() (BlockResultClient, error) {
 		return client, nil
 	}
 
-	return NewBlockSourceWithDialOptions(getClient, notifier, log.NewNopLogger(), Timeout(timeout))
+	var t time.Duration
+	for _, timeout := range timeout {
+		t = timeout
+	}
+
+	return NewBlockSourceWithDialOptions(getClient, notifier, log.NewNopLogger(), Timeout(t))
 }
 
 // NewBlockSourceWithDialOptions returns a new BlockSource instance with dial options

--- a/events/source.go
+++ b/events/source.go
@@ -364,11 +364,11 @@ func NewBlockNotifier(client BlockClient, logger log.Logger, options ...DialOpti
 	getClient := func() (BlockClient, error) {
 		return client, nil
 	}
-	return NewBlockNotifierWithClient(getClient, logger, options...)
+	return NewBlockNotifierWithDialOptions(getClient, logger, options...)
 }
 
-// NewBlockNotifierWithClient returns a new BlockNotifier instance
-func NewBlockNotifierWithClient(getClient BlockClientFactory, logger log.Logger, options ...DialOption) *Notifier {
+// NewBlockNotifierWithDialOptions returns a new BlockNotifier instance with dial options
+func NewBlockNotifierWithDialOptions(getClient BlockClientFactory, logger log.Logger, options ...DialOption) *Notifier {
 	var opts dialOptions
 	for _, option := range options {
 		opts = option.apply(opts)
@@ -513,7 +513,17 @@ type BlockResultClient interface {
 }
 
 // NewBlockSource returns a new BlockSource instance
-func NewBlockSource(getClient BlockResultClientFactory, notifier BlockNotifier, logger log.Logger, options ...DialOption) BlockSource {
+// NewBlockSource maintains compatibility with vald
+func NewBlockSource(client BlockResultClient, notifier BlockNotifier, timeout time.Duration) BlockSource {
+	getClient := func() (BlockResultClient, error) {
+		return client, nil
+	}
+
+	return NewBlockSourceWithDialOptions(getClient, notifier, log.NewNopLogger(), Timeout(timeout))
+}
+
+// NewBlockSourceWithDialOptions returns a new BlockSource instance with dial options
+func NewBlockSourceWithDialOptions(getClient BlockResultClientFactory, notifier BlockNotifier, logger log.Logger, options ...DialOption) BlockSource {
 	var opts dialOptions
 	for _, option := range options {
 		opts = option.apply(opts)

--- a/events/source.go
+++ b/events/source.go
@@ -504,7 +504,7 @@ type BlockResultClient interface {
 }
 
 // NewBlockSource returns a new BlockSource instance
-func NewBlockSource(getClient BlockResultClientFactory, notifier BlockNotifier, options ...DialOption) BlockSource {
+func NewBlockSource(getClient BlockResultClientFactory, notifier BlockNotifier, logger log.Logger, options ...DialOption) BlockSource {
 	var opts dialOptions
 	for _, option := range options {
 		opts = option.apply(opts)
@@ -516,6 +516,7 @@ func NewBlockSource(getClient BlockResultClientFactory, notifier BlockNotifier, 
 		retries:   opts.retries,
 		backOff:   opts.backOff,
 		timeout:   opts.timeout,
+		logger:    logger,
 	}
 }
 

--- a/events/source.go
+++ b/events/source.go
@@ -209,6 +209,10 @@ func (b *eventblockNotifier) tryUnsubscribe(ctx context.Context, timeout time.Du
 	ctx, cancel := ctxWithTimeout(ctx, timeout)
 	defer cancel()
 
+	if b.client == nil {
+		return
+	}
+
 	// this unsubscribe is a best-effort action, we still try to continue as usual if it fails, so errors are only logged
 	err := b.client.Unsubscribe(ctx, "", b.query)
 	if err != nil {

--- a/events/source.go
+++ b/events/source.go
@@ -222,7 +222,7 @@ func newQueryBlockNotifier(client BlockHeightClient, logger log.Logger, options 
 	}
 }
 
-func (q queryBlockNotifier) BlockHeights(ctx context.Context) (<-chan int64, <-chan error) {
+func (q *queryBlockNotifier) BlockHeights(ctx context.Context) (<-chan int64, <-chan error) {
 	blocks := make(chan int64)
 	errChan := make(chan error, 1)
 
@@ -304,7 +304,7 @@ type Notifier struct {
 }
 
 // Done returns a channel that is closed when the Notifier has completed cleanup
-func (b Notifier) Done() <-chan struct{} {
+func (b *Notifier) Done() <-chan struct{} {
 	return b.eventsNotifier.Done()
 }
 
@@ -331,7 +331,7 @@ func NewBlockNotifier(client BlockClient, logger log.Logger, options ...DialOpti
 }
 
 // StartingAt sets the start block from which to receive notifications
-func (b Notifier) StartingAt(block int64) Notifier {
+func (b *Notifier) StartingAt(block int64) Notifier {
 	if block > 0 {
 		b.start = block
 	}
@@ -340,7 +340,7 @@ func (b Notifier) StartingAt(block int64) Notifier {
 
 // BlockHeights returns a channel with the block heights from the beginning of the chain to all newly discovered blocks.
 // Optionally, starts at the given start block.
-func (b Notifier) BlockHeights(ctx context.Context) (<-chan int64, <-chan error) {
+func (b *Notifier) BlockHeights(ctx context.Context) (<-chan int64, <-chan error) {
 	errChan := make(chan error, 1)
 	b.running, b.shutdown = context.WithCancel(ctx)
 
@@ -357,7 +357,7 @@ func (b Notifier) BlockHeights(ctx context.Context) (<-chan int64, <-chan error)
 	return blocks, errChan
 }
 
-func (b Notifier) handleErrors(eventErrs <-chan error, queryErrs <-chan error, errChan chan error) {
+func (b *Notifier) handleErrors(eventErrs <-chan error, queryErrs <-chan error, errChan chan error) {
 	defer b.shutdown()
 
 	for {
@@ -374,7 +374,7 @@ func (b Notifier) handleErrors(eventErrs <-chan error, queryErrs <-chan error, e
 	}
 }
 
-func (b Notifier) pipeLatestBlock(fromQuery <-chan int64, fromEvents <-chan int64, blockHeights chan int64) {
+func (b *Notifier) pipeLatestBlock(fromQuery <-chan int64, fromEvents <-chan int64, blockHeights chan int64) {
 	defer close(blockHeights)
 	defer b.logger.Info("stopped block sync")
 

--- a/events/source.go
+++ b/events/source.go
@@ -649,7 +649,7 @@ func ctxWithTimeout(ctx context.Context, timeout time.Duration) (context.Context
 func ToBlockClientFactory(f ClientFactory) BlockClientFactory {
 	return func() (BlockClient, error) {
 		c, err := f()
-		if err == nil {
+		if err != nil {
 			return nil, err
 		}
 

--- a/events/source.go
+++ b/events/source.go
@@ -202,7 +202,7 @@ func (b *eventblockNotifier) subscribe(ctx context.Context) (<-chan coretypes.Re
 		return b.client.Subscribe(ctx, "", b.query, WebsocketQueueSize)
 	}
 
-	backOff := utils.LinearBackOff(b.backOff)
+	backOff := utils.ExponentialBackOff(b.backOff)
 	for ; i <= b.retries; i++ {
 		eventChan, err := trySubscribe()
 		if err == nil {
@@ -319,7 +319,7 @@ func (q *queryBlockNotifier) latestFromSyncStatus(ctx context.Context) (int64, e
 		return q.client.LatestBlockHeight(ctx)
 	}
 
-	backOff := utils.LinearBackOff(q.backOff)
+	backOff := utils.ExponentialBackOff(q.backOff)
 	for ; i <= q.retries; i++ {
 		latestBlockHeight, err := tryQuery()
 		if err == nil {

--- a/events/source.go
+++ b/events/source.go
@@ -660,7 +660,7 @@ func ctxWithTimeout(ctx context.Context, timeout time.Duration) (context.Context
 	return context.WithTimeout(ctx, timeout)
 }
 
-// BlockClientAdapter adapts a Tendermint client factory to a BlockClientFactory
+// BlockClientAdapter adapts a Tendermint ClientFactory to a BlockClientFactory
 func BlockClientAdapter(f ClientFactory) BlockClientFactory {
 	return func() (BlockClient, error) {
 		c, err := f()
@@ -672,7 +672,7 @@ func BlockClientAdapter(f ClientFactory) BlockClientFactory {
 	}
 }
 
-// BlockResultClientAdapter adapts a Tendermint client factory  to a BlockResultClientFactory
+// BlockResultClientAdapter adapts a Tendermint ClientFactory  to a BlockResultClientFactory
 func BlockResultClientAdapter(f ClientFactory) BlockResultClientFactory {
 	return func() (BlockResultClient, error) {
 		return f()

--- a/events/source2_test.go
+++ b/events/source2_test.go
@@ -240,7 +240,7 @@ func (t *testEnv) ResultsClient() error {
 }
 
 func (t *testEnv) BlockResultSource() error {
-	t.blockSource = events.NewBlockSource(t.getResultClient(), t.notifierMock, log.TestingLogger(), events.Timeout(time.Second))
+	t.blockSource = events.NewBlockSource(t.resultsClient, t.notifierMock, time.Second)
 	return nil
 }
 

--- a/events/source2_test.go
+++ b/events/source2_test.go
@@ -50,8 +50,20 @@ func (t *testEnv) Context() error {
 	return nil
 }
 
+func (t *testEnv) getBlockClient() events.BlockClientFactory {
+	return func() (events.BlockClient, error) {
+		return t.notifierClient, nil
+	}
+}
+
+func (t *testEnv) getResultClient() events.BlockResultClientFactory {
+	return func() (events.BlockResultClient, error) {
+		return t.resultsClient, nil
+	}
+}
+
 func (t *testEnv) BlockNotifierStartingAtBlock(start int64) error {
-	t.notifier = events.NewBlockNotifier(t.notifierClient, log.TestingLogger(),
+	t.notifier = events.NewBlockNotifier(t.getBlockClient(), log.TestingLogger(),
 		events.Timeout(1*time.Millisecond), events.Retries(1), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 	return nil
 }
@@ -228,7 +240,7 @@ func (t *testEnv) ResultsClient() error {
 }
 
 func (t *testEnv) BlockResultSource() error {
-	t.blockSource = events.NewBlockSource(t.resultsClient, t.notifierMock, 1*time.Second)
+	t.blockSource = events.NewBlockSource(t.getResultClient(), t.notifierMock, events.Timeout(time.Second))
 	return nil
 }
 

--- a/events/source2_test.go
+++ b/events/source2_test.go
@@ -240,7 +240,7 @@ func (t *testEnv) ResultsClient() error {
 }
 
 func (t *testEnv) BlockResultSource() error {
-	t.blockSource = events.NewBlockSource(t.getResultClient(), t.notifierMock, events.Timeout(time.Second))
+	t.blockSource = events.NewBlockSource(t.getResultClient(), t.notifierMock, log.TestingLogger(), events.Timeout(time.Second))
 	return nil
 }
 

--- a/events/source2_test.go
+++ b/events/source2_test.go
@@ -63,7 +63,7 @@ func (t *testEnv) getResultClient() events.BlockResultClientFactory {
 }
 
 func (t *testEnv) BlockNotifierStartingAtBlock(start int64) error {
-	t.notifier = events.NewBlockNotifier(t.getBlockClient(), log.TestingLogger(),
+	t.notifier = events.NewBlockNotifier(t.notifierClient, log.TestingLogger(),
 		events.Timeout(1*time.Millisecond), events.Retries(1), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 	return nil
 }

--- a/events/source_test.go
+++ b/events/source_test.go
@@ -34,7 +34,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 			return nil, nil
 		}
 		start := rand.I64Between(0, 1000000)
-		notifier := events.NewBlockNotifier(getBlockClient(client), log.TestingLogger(),
+		notifier := events.NewBlockNotifier(client, log.TestingLogger(),
 			events.Timeout(1*time.Second), events.Retries(1), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 
 		newBlockCount := rand.I64Between(1, 20)
@@ -61,7 +61,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 	t.Run("GIVEN only events are responsive THEN sync all blocks", testutils.Func(func(t *testing.T) {
 		client := NewClientMock()
 		start := rand.I64Between(0, 1000000)
-		notifier := events.NewBlockNotifier(getBlockClient(client), log.TestingLogger(),
+		notifier := events.NewBlockNotifier(client, log.TestingLogger(),
 			events.Timeout(1*time.Millisecond), events.Retries(1), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 
 		receivedBlocks, errChan := notifier.BlockHeights(context.Background())
@@ -89,7 +89,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 	t.Run("GIVEN context is canceled THEN shutdown gracefully", testutils.Func(func(t *testing.T) {
 		client := NewClientMock()
 		start := rand.I64Between(0, 1000000)
-		notifier := events.NewBlockNotifier(getBlockClient(client), log.TestingLogger(),
+		notifier := events.NewBlockNotifier(client, log.TestingLogger(),
 			events.Timeout(1*time.Millisecond), events.Retries(1), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 
 		ctx, cancelMainCtx := context.WithCancel(context.Background())
@@ -141,7 +141,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 			return nil, fmt.Errorf("some error")
 		}
 		start := rand.I64Between(0, 1000000)
-		notifier := events.NewBlockNotifier(getBlockClient(client), log.TestingLogger(), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
+		notifier := events.NewBlockNotifier(client, log.TestingLogger(), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 
 		blocks, errChan := notifier.BlockHeights(context.Background())
 
@@ -175,7 +175,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 			return 0, fmt.Errorf("some error")
 		}
 		start := rand.I64Between(0, 1000000)
-		notifier := events.NewBlockNotifier(getBlockClient(client), log.TestingLogger(), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
+		notifier := events.NewBlockNotifier(client, log.TestingLogger(), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 
 		blocks, errChan := notifier.BlockHeights(context.Background())
 
@@ -206,7 +206,7 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 		start := rand.PosI64()
 		client.NextBlock(start)
 
-		notifier := events.NewBlockNotifier(getBlockClient(client), log.TestingLogger(), events.KeepAlive(1*time.Millisecond)).StartingAt(-rand.PosI64())
+		notifier := events.NewBlockNotifier(client, log.TestingLogger(), events.KeepAlive(1*time.Millisecond)).StartingAt(-rand.PosI64())
 
 		blocks, errChan := notifier.BlockHeights(context.Background())
 


### PR DESCRIPTION
## Description

- fixes fault tolerance in block client to re-establish the tendermint client connect upon each failure
- adds this mechanism to the block result client which previously could not tolerate a single request error

NB: The connection fault management should be refactored to work the same way that it does in EVM EDS such that all the logic is not duplicated between queries.
- in EVM EDS the client itself has one request fault management mechanism which is shared by all request types whereas here each caller of the client implements its own mechanism. 
- see https://github.com/axelarnetwork/axelar-eds/blob/ae68de669a10c0d163bbe04c90c894380dd06bec/evm-notifier/client.go#L152

### Other notes

Notifier factories return pointers but use value and pointer receivers inconsistently. There's no need to use a value receiver when we already have a pointer.

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
