### PR TITLE
fix: use the latest block height of the network

### DIFF
--- a/events/mock/source.go
+++ b/events/mock/source.go
@@ -124,6 +124,9 @@ var _ events.BlockClient = &BlockClientMock{}
 // 			LatestBlockHeightFunc: func(ctx context.Context) (int64, error) {
 // 				panic("mock out the LatestBlockHeight method")
 // 			},
+// 			LatestNodeBlockHeightFunc: func(ctx context.Context) (int64, error) {
+// 				panic("mock out the LatestNodeBlockHeight method")
+// 			},
 // 			SubscribeFunc: func(ctx context.Context, subscriber string, query string, outCapacity ...int) (<-chan coretypes.ResultEvent, error) {
 // 				panic("mock out the Subscribe method")
 // 			},
@@ -140,6 +143,9 @@ type BlockClientMock struct {
 	// LatestBlockHeightFunc mocks the LatestBlockHeight method.
 	LatestBlockHeightFunc func(ctx context.Context) (int64, error)
 
+	// LatestNodeBlockHeightFunc mocks the LatestNodeBlockHeight method.
+	LatestNodeBlockHeightFunc func(ctx context.Context) (int64, error)
+
 	// SubscribeFunc mocks the Subscribe method.
 	SubscribeFunc func(ctx context.Context, subscriber string, query string, outCapacity ...int) (<-chan coretypes.ResultEvent, error)
 
@@ -150,6 +156,11 @@ type BlockClientMock struct {
 	calls struct {
 		// LatestBlockHeight holds details about calls to the LatestBlockHeight method.
 		LatestBlockHeight []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+		}
+		// LatestNodeBlockHeight holds details about calls to the LatestNodeBlockHeight method.
+		LatestNodeBlockHeight []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -174,9 +185,10 @@ type BlockClientMock struct {
 			Query string
 		}
 	}
-	lockLatestBlockHeight sync.RWMutex
-	lockSubscribe         sync.RWMutex
-	lockUnsubscribe       sync.RWMutex
+	lockLatestBlockHeight     sync.RWMutex
+	lockLatestNodeBlockHeight sync.RWMutex
+	lockSubscribe             sync.RWMutex
+	lockUnsubscribe           sync.RWMutex
 }
 
 // LatestBlockHeight calls LatestBlockHeightFunc.
@@ -207,6 +219,37 @@ func (mock *BlockClientMock) LatestBlockHeightCalls() []struct {
 	mock.lockLatestBlockHeight.RLock()
 	calls = mock.calls.LatestBlockHeight
 	mock.lockLatestBlockHeight.RUnlock()
+	return calls
+}
+
+// LatestNodeBlockHeight calls LatestNodeBlockHeightFunc.
+func (mock *BlockClientMock) LatestNodeBlockHeight(ctx context.Context) (int64, error) {
+	if mock.LatestNodeBlockHeightFunc == nil {
+		panic("BlockClientMock.LatestNodeBlockHeightFunc: method is nil but BlockClient.LatestNodeBlockHeight was just called")
+	}
+	callInfo := struct {
+		Ctx context.Context
+	}{
+		Ctx: ctx,
+	}
+	mock.lockLatestNodeBlockHeight.Lock()
+	mock.calls.LatestNodeBlockHeight = append(mock.calls.LatestNodeBlockHeight, callInfo)
+	mock.lockLatestNodeBlockHeight.Unlock()
+	return mock.LatestNodeBlockHeightFunc(ctx)
+}
+
+// LatestNodeBlockHeightCalls gets all the calls that were made to LatestNodeBlockHeight.
+// Check the length with:
+//     len(mockedBlockClient.LatestNodeBlockHeightCalls())
+func (mock *BlockClientMock) LatestNodeBlockHeightCalls() []struct {
+	Ctx context.Context
+} {
+	var calls []struct {
+		Ctx context.Context
+	}
+	mock.lockLatestNodeBlockHeight.RLock()
+	calls = mock.calls.LatestNodeBlockHeight
+	mock.lockLatestNodeBlockHeight.RUnlock()
 	return calls
 }
 

--- a/events/source2_test.go
+++ b/events/source2_test.go
@@ -70,6 +70,7 @@ func (t *testEnv) ClientWithoutSubscription() error {
 
 func (t *testEnv) ClientWithStaleQuery() error {
 	t.notifierClient.LatestBlockHeightFunc = func(context.Context) (int64, error) { return 0, nil }
+	t.notifierClient.LatestNodeBlockHeightFunc = func(context.Context) (int64, error) { return 0, nil }
 	return nil
 }
 
@@ -82,6 +83,9 @@ func (t *testEnv) ClientSubscriptionFails() error {
 
 func (t *testEnv) ClientQueryFails() error {
 	t.notifierClient.LatestBlockHeightFunc = func(context.Context) (int64, error) {
+		return 0, fmt.Errorf("some error")
+	}
+	t.notifierClient.LatestNodeBlockHeightFunc = func(context.Context) (int64, error) {
 		return 0, fmt.Errorf("some error")
 	}
 	return nil

--- a/events/source_test.go
+++ b/events/source_test.go
@@ -168,6 +168,9 @@ func TestBlockNotifier_BlockHeights(t *testing.T) {
 		client.LatestBlockHeightFunc = func(context.Context) (int64, error) {
 			return 0, fmt.Errorf("some error")
 		}
+		client.LatestNodeBlockHeightFunc = func(context.Context) (int64, error) {
+			return 0, fmt.Errorf("some error")
+		}
 		start := rand.I64Between(0, 1000000)
 		notifier := events.NewBlockNotifier(client, log.TestingLogger(), events.KeepAlive(1*time.Millisecond)).StartingAt(start)
 
@@ -238,7 +241,8 @@ func NewClientMock() *clientMock {
 
 	subscriptionCtx, subscriptionCancel := context.WithCancel(context.Background())
 	blockClientMock := &mock.BlockClientMock{
-		LatestBlockHeightFunc: func(context.Context) (int64, error) { return client.LatestBlock, nil },
+		LatestBlockHeightFunc:     func(context.Context) (int64, error) { return client.LatestBlock, nil },
+		LatestNodeBlockHeightFunc: func(context.Context) (int64, error) { return client.LatestBlock, nil },
 		SubscribeFunc: func(_ context.Context, _ string, _ string, out ...int) (<-chan coretypes.ResultEvent, error) {
 			eventChan := make(chan coretypes.ResultEvent, out[0])
 

--- a/tendermint/client.go
+++ b/tendermint/client.go
@@ -56,12 +56,12 @@ func (r *RobustClient) BlockResults(ctx context.Context, height *int64) (results
 	return results, err
 }
 
-// LatestBlockHeight returns the height of the latest block
+// LatestBlockHeight returns the height of the latest block in the network
 func (r *RobustClient) LatestBlockHeight(ctx context.Context) (int64, error) {
-	var status *coretypes.ResultStatus
+	var status *coretypes.ResultABCIInfo
 	var err error
 	err = r.execute(func() error {
-		status, err = r.client.Status(ctx)
+		status, err = r.client.ABCIInfo(ctx)
 		return err
 	})
 
@@ -69,7 +69,7 @@ func (r *RobustClient) LatestBlockHeight(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 
-	return status.SyncInfo.LatestBlockHeight, nil
+	return status.Response.LastBlockHeight, nil
 }
 
 // Stop stops the client and closes the server connection

--- a/tendermint/client.go
+++ b/tendermint/client.go
@@ -72,6 +72,22 @@ func (r *RobustClient) LatestBlockHeight(ctx context.Context) (int64, error) {
 	return status.Response.LastBlockHeight, nil
 }
 
+// LatestNodeBlockHeight returns the height of the latest block synced by the RPC node
+func (r *RobustClient) LatestNodeBlockHeight(ctx context.Context) (int64, error) {
+	var status *coretypes.ResultStatus
+	var err error
+	err = r.execute(func() error {
+		status, err = r.client.Status(ctx)
+		return err
+	})
+
+	if err != nil {
+		return 0, err
+	}
+
+	return status.SyncInfo.LatestBlockHeight, nil
+}
+
 // Stop stops the client and closes the server connection
 func (r *RobustClient) Stop() error {
 	return r.execute(func() error { return r.client.Stop() })

--- a/tendermint/client_test.go
+++ b/tendermint/client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/rpc/client"
 	coretypes "github.com/tendermint/tendermint/rpc/core/types"
 
@@ -25,14 +26,14 @@ func TestResettableClient(t *testing.T) {
 			untilFailure := rand.I64Between(1, 100)
 			calls := int64(0)
 			return &mock.ClientMock{
-				StatusFunc: func(context.Context) (*coretypes.ResultStatus, error) {
+				ABCIInfoFunc: func(context.Context) (*coretypes.ResultABCIInfo, error) {
 					calls++
 					if calls > untilFailure {
 						return nil, fmt.Errorf("post failed: some connection error")
 					}
 
-					return &coretypes.ResultStatus{
-						SyncInfo: coretypes.SyncInfo{LatestBlockHeight: expectedBlockHeight},
+					return &coretypes.ResultABCIInfo{
+						Response: types.ResponseInfo{LastBlockHeight: expectedBlockHeight},
 					}, nil
 				},
 				StopFunc: func() error { return nil },


### PR DESCRIPTION
## Description

- Fixes axelarnetwork/axelar-core#1296

## Todos

- [ ] Unit tests
- [ ] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
