### PR TITLE
feat: add query to retrieve node sync info

### DIFF
--- a/events/mock/source.go
+++ b/events/mock/source.go
@@ -121,8 +121,8 @@ var _ events.BlockClient = &BlockClientMock{}
 //
 // 		// make and configure a mocked events.BlockClient
 // 		mockedBlockClient := &BlockClientMock{
-// 			LatestBlockHeightFunc: func(ctx context.Context) (int64, error) {
-// 				panic("mock out the LatestBlockHeight method")
+// 			LatestSyncInfoFunc: func(ctx context.Context) (*coretypes.SyncInfo, error) {
+// 				panic("mock out the LatestSyncInfo method")
 // 			},
 // 			SubscribeFunc: func(ctx context.Context, subscriber string, query string, outCapacity ...int) (<-chan coretypes.ResultEvent, error) {
 // 				panic("mock out the Subscribe method")
@@ -137,8 +137,8 @@ var _ events.BlockClient = &BlockClientMock{}
 //
 // 	}
 type BlockClientMock struct {
-	// LatestBlockHeightFunc mocks the LatestBlockHeight method.
-	LatestBlockHeightFunc func(ctx context.Context) (int64, error)
+	// LatestSyncInfoFunc mocks the LatestSyncInfo method.
+	LatestSyncInfoFunc func(ctx context.Context) (*coretypes.SyncInfo, error)
 
 	// SubscribeFunc mocks the Subscribe method.
 	SubscribeFunc func(ctx context.Context, subscriber string, query string, outCapacity ...int) (<-chan coretypes.ResultEvent, error)
@@ -148,8 +148,8 @@ type BlockClientMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// LatestBlockHeight holds details about calls to the LatestBlockHeight method.
-		LatestBlockHeight []struct {
+		// LatestSyncInfo holds details about calls to the LatestSyncInfo method.
+		LatestSyncInfo []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 		}
@@ -174,39 +174,39 @@ type BlockClientMock struct {
 			Query string
 		}
 	}
-	lockLatestBlockHeight sync.RWMutex
-	lockSubscribe         sync.RWMutex
-	lockUnsubscribe       sync.RWMutex
+	lockLatestSyncInfo sync.RWMutex
+	lockSubscribe      sync.RWMutex
+	lockUnsubscribe    sync.RWMutex
 }
 
-// LatestBlockHeight calls LatestBlockHeightFunc.
-func (mock *BlockClientMock) LatestBlockHeight(ctx context.Context) (int64, error) {
-	if mock.LatestBlockHeightFunc == nil {
-		panic("BlockClientMock.LatestBlockHeightFunc: method is nil but BlockClient.LatestBlockHeight was just called")
+// LatestSyncInfo calls LatestSyncInfoFunc.
+func (mock *BlockClientMock) LatestSyncInfo(ctx context.Context) (*coretypes.SyncInfo, error) {
+	if mock.LatestSyncInfoFunc == nil {
+		panic("BlockClientMock.LatestSyncInfoFunc: method is nil but BlockClient.LatestSyncInfo was just called")
 	}
 	callInfo := struct {
 		Ctx context.Context
 	}{
 		Ctx: ctx,
 	}
-	mock.lockLatestBlockHeight.Lock()
-	mock.calls.LatestBlockHeight = append(mock.calls.LatestBlockHeight, callInfo)
-	mock.lockLatestBlockHeight.Unlock()
-	return mock.LatestBlockHeightFunc(ctx)
+	mock.lockLatestSyncInfo.Lock()
+	mock.calls.LatestSyncInfo = append(mock.calls.LatestSyncInfo, callInfo)
+	mock.lockLatestSyncInfo.Unlock()
+	return mock.LatestSyncInfoFunc(ctx)
 }
 
-// LatestBlockHeightCalls gets all the calls that were made to LatestBlockHeight.
+// LatestSyncInfoCalls gets all the calls that were made to LatestSyncInfo.
 // Check the length with:
-//     len(mockedBlockClient.LatestBlockHeightCalls())
-func (mock *BlockClientMock) LatestBlockHeightCalls() []struct {
+//     len(mockedBlockClient.LatestSyncInfoCalls())
+func (mock *BlockClientMock) LatestSyncInfoCalls() []struct {
 	Ctx context.Context
 } {
 	var calls []struct {
 		Ctx context.Context
 	}
-	mock.lockLatestBlockHeight.RLock()
-	calls = mock.calls.LatestBlockHeight
-	mock.lockLatestBlockHeight.RUnlock()
+	mock.lockLatestSyncInfo.RLock()
+	calls = mock.calls.LatestSyncInfo
+	mock.lockLatestSyncInfo.RUnlock()
 	return calls
 }
 

--- a/events/source.go
+++ b/events/source.go
@@ -201,7 +201,7 @@ func (b *eventblockNotifier) Done() chan struct{} {
 }
 
 type queryBlockNotifier struct {
-	client            BlockInfoClient
+	client            SyncInfoClient
 	retries           int
 	timeout           time.Duration
 	backOff           time.Duration
@@ -209,7 +209,7 @@ type queryBlockNotifier struct {
 	logger            log.Logger
 }
 
-func newQueryBlockNotifier(client BlockInfoClient, logger log.Logger, options ...DialOption) *queryBlockNotifier {
+func newQueryBlockNotifier(client SyncInfoClient, logger log.Logger, options ...DialOption) *queryBlockNotifier {
 	var opts dialOptions
 	for _, option := range options {
 		opts = option.apply(opts)
@@ -278,8 +278,8 @@ func (q *queryBlockNotifier) latestFromSyncStatus(ctx context.Context) (int64, e
 	return 0, fmt.Errorf("aborting sync status retrieval after %d attemts ", q.retries+1)
 }
 
-// BlockInfoClient can query the node's sync info
-type BlockInfoClient interface {
+// SyncInfoClient can query the node's sync info
+type SyncInfoClient interface {
 	LatestSyncInfo(ctx context.Context) (*coretypes.SyncInfo, error)
 }
 
@@ -289,9 +289,9 @@ type SubscriptionClient interface {
 	Unsubscribe(ctx context.Context, subscriber, query string) error
 }
 
-// BlockClient is both BlockInfoClient and SubscriptionClient
+// BlockClient is both SyncInfoClient and SubscriptionClient
 type BlockClient interface {
-	BlockInfoClient
+	SyncInfoClient
 	SubscriptionClient
 }
 
@@ -345,7 +345,7 @@ func (b *Notifier) getLatestBlockHeight() (int64, error) {
 	defer cancel()
 	info, err := b.client.LatestSyncInfo(ctx)
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 
 	return info.LatestBlockHeight, nil

--- a/events/source.go
+++ b/events/source.go
@@ -201,7 +201,7 @@ func (b *eventblockNotifier) Done() chan struct{} {
 }
 
 type queryBlockNotifier struct {
-	client            BlockHeightClient
+	client            BlockInfoClient
 	retries           int
 	timeout           time.Duration
 	backOff           time.Duration
@@ -209,7 +209,7 @@ type queryBlockNotifier struct {
 	logger            log.Logger
 }
 
-func newQueryBlockNotifier(client BlockHeightClient, logger log.Logger, options ...DialOption) *queryBlockNotifier {
+func newQueryBlockNotifier(client BlockInfoClient, logger log.Logger, options ...DialOption) *queryBlockNotifier {
 	var opts dialOptions
 	for _, option := range options {
 		opts = option.apply(opts)
@@ -266,10 +266,10 @@ func (q *queryBlockNotifier) latestFromSyncStatus(ctx context.Context) (int64, e
 	backOff := utils.LinearBackOff(q.backOff)
 	for i := 0; i <= q.retries; i++ {
 		ctx, cancel := ctxWithTimeout(ctx, q.timeout)
-		latestBlockHeight, err := q.client.LatestBlockHeight(ctx)
+		syncInfo, err := q.client.LatestSyncInfo(ctx)
 		cancel()
 		if err == nil {
-			return latestBlockHeight, nil
+			return syncInfo.LatestBlockHeight, nil
 		}
 
 		q.logger.Info(sdkerrors.Wrapf(err, "failed to retrieve node status, attempt %d", i+1).Error())
@@ -278,9 +278,9 @@ func (q *queryBlockNotifier) latestFromSyncStatus(ctx context.Context) (int64, e
 	return 0, fmt.Errorf("aborting sync status retrieval after %d attemts ", q.retries+1)
 }
 
-// BlockHeightClient can query the latest block height
-type BlockHeightClient interface {
-	LatestBlockHeight(ctx context.Context) (int64, error)
+// BlockInfoClient can query the node's sync info
+type BlockInfoClient interface {
+	LatestSyncInfo(ctx context.Context) (*coretypes.SyncInfo, error)
 }
 
 // SubscriptionClient subscribes to and unsubscribes from Tendermint events
@@ -289,9 +289,9 @@ type SubscriptionClient interface {
 	Unsubscribe(ctx context.Context, subscriber, query string) error
 }
 
-// BlockClient is both BlockHeightClient and SubscriptionClient
+// BlockClient is both BlockInfoClient and SubscriptionClient
 type BlockClient interface {
-	BlockHeightClient
+	BlockInfoClient
 	SubscriptionClient
 }
 
@@ -343,7 +343,12 @@ func (b *Notifier) StartingAt(block int64) *Notifier {
 func (b *Notifier) getLatestBlockHeight() (int64, error) {
 	ctx, cancel := ctxWithTimeout(context.Background(), b.timeout)
 	defer cancel()
-	return b.client.LatestBlockHeight(ctx)
+	info, err := b.client.LatestSyncInfo(ctx)
+	if err != nil {
+		return 0, nil
+	}
+
+	return info.LatestBlockHeight, nil
 }
 
 // BlockHeights returns a channel with the block heights from the beginning of the chain to all newly discovered blocks.

--- a/events/source2_test.go
+++ b/events/source2_test.go
@@ -69,7 +69,9 @@ func (t *testEnv) ClientWithoutSubscription() error {
 }
 
 func (t *testEnv) ClientWithStaleQuery() error {
-	t.notifierClient.LatestBlockHeightFunc = func(context.Context) (int64, error) { return 0, nil }
+	t.notifierClient.LatestSyncInfoFunc = func(context.Context) (*coretypes.SyncInfo, error) {
+		return &coretypes.SyncInfo{}, nil
+	}
 	return nil
 }
 
@@ -81,8 +83,8 @@ func (t *testEnv) ClientSubscriptionFails() error {
 }
 
 func (t *testEnv) ClientQueryFails() error {
-	t.notifierClient.LatestBlockHeightFunc = func(context.Context) (int64, error) {
-		return 0, fmt.Errorf("some error")
+	t.notifierClient.LatestSyncInfoFunc = func(context.Context) (*coretypes.SyncInfo, error) {
+		return nil, fmt.Errorf("some error")
 	}
 	return nil
 }

--- a/tendermint/client.go
+++ b/tendermint/client.go
@@ -56,8 +56,8 @@ func (r *RobustClient) BlockResults(ctx context.Context, height *int64) (results
 	return results, err
 }
 
-// LatestBlockHeight returns the height of the latest block
-func (r *RobustClient) LatestBlockHeight(ctx context.Context) (int64, error) {
+// LatestSyncInfo returns the sync info of the node
+func (r *RobustClient) LatestSyncInfo(ctx context.Context) (*coretypes.SyncInfo, error) {
 	var status *coretypes.ResultStatus
 	var err error
 	err = r.execute(func() error {
@@ -66,10 +66,10 @@ func (r *RobustClient) LatestBlockHeight(ctx context.Context) (int64, error) {
 	})
 
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return status.SyncInfo.LatestBlockHeight, nil
+	return &status.SyncInfo, nil
 }
 
 // Stop stops the client and closes the server connection

--- a/tendermint/client_test.go
+++ b/tendermint/client_test.go
@@ -42,16 +42,16 @@ func TestResettableClient(t *testing.T) {
 		When("calling a tendermint function until the connection fails", func(t *testing.T) {
 			var err error
 			for err == nil {
-				var blockHeight int64
-				blockHeight, err = resettableClient.LatestBlockHeight(context.Background())
+				var syncInfo *coretypes.SyncInfo
+				syncInfo, err = resettableClient.LatestSyncInfo(context.Background())
 				if err == nil {
-					assert.Equal(t, expectedBlockHeight, blockHeight)
+					assert.Equal(t, expectedBlockHeight, syncInfo.LatestBlockHeight)
 				}
 			}
 		}).
 		Then("recover the connection", func(t *testing.T) {
-			blockHeight, err := resettableClient.LatestBlockHeight(context.Background())
+			syncInfo, err := resettableClient.LatestSyncInfo(context.Background())
 			assert.NoError(t, err)
-			assert.Equal(t, expectedBlockHeight, blockHeight)
+			assert.Equal(t, expectedBlockHeight, syncInfo.LatestBlockHeight)
 		}).Run(t, 20)
 }


### PR DESCRIPTION
## Description

Return the node sync info to allow vald to determine if a node is synced.

## Todos

- [ ] Unit tests
- [x] Manual tests
- [ ] Documentation
- [ ] Connect epics/issues
- [ ] Tag type of change

## Steps to Test

## Expected Behaviour

## Other Notes
