### PR TITLE
fix: use gogoproto instead of gogo/protobuf in Filter

### DIFF
--- a/events/filter.go
+++ b/events/filter.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/go-errors/errors"
-	"github.com/gogo/protobuf/proto"
 
 	"github.com/axelarnetwork/utils/jobs"
 )

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/axelarnetwork/utils v0.0.0-20250317211301-dd7399dbbc5f
 	github.com/cometbft/cometbft v0.38.19
 	github.com/cosmos/cosmos-sdk v0.50.14
+	github.com/cosmos/gogoproto v1.7.0
 	github.com/cucumber/godog v0.12.5
 	github.com/go-errors/errors v1.5.1
-	github.com/gogo/protobuf v1.3.2
 	github.com/matryer/moq v0.6.0
 	github.com/smallnest/chanx v1.0.1-0.20211205150931-349643806662
 	github.com/spf13/cobra v1.9.1
@@ -39,7 +39,6 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-db v1.1.1 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5 // indirect
-	github.com/cosmos/gogoproto v1.7.0 // indirect
 	github.com/cosmos/ics23/go v0.11.0 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
 	github.com/cucumber/messages-go/v16 v16.0.1 // indirect
@@ -53,6 +52,7 @@ require (
 	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.6.0 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/glog v1.2.3 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect


### PR DESCRIPTION
## Problem

The `Filter` function in `events/filter.go` was using `github.com/gogo/protobuf/proto` which is incompatible with cosmos-sdk v0.50 types that use `github.com/cosmos/gogoproto/proto`.

This caused `proto.MessageName()` to return empty strings for gogoproto types, resulting in **all filters matching all events** (since `"" == ""`). This caused events to be routed to the wrong handlers, leading to panics.

### Observed Panic
```
job panicked: interface conversion: interface {} is *types.KeygenStarted, not *types.SigningStarted
```

This occurred because `KeygenStarted` events were incorrectly passing the `SigningStarted` filter and being sent to the signing job handler, which then panicked when trying to cast the event.

## Root Cause

In commit f03db36, the migration from gogo/protobuf to gogoproto was done for some files but `events/filter.go` was missed. The Filter function uses `proto.MessageName()` to compare event types:

```go
return proto.MessageName(typedEvent) == proto.MessageName(*new(T))
```

When using the old `gogo/protobuf` package with new `gogoproto` types, `MessageName()` returns empty strings, causing the comparison to always succeed.

## Solution

Update `events/filter.go` to use `github.com/cosmos/gogoproto/proto` instead of `github.com/gogo/protobuf/proto`, ensuring compatibility with cosmos-sdk v0.50.

## Testing

Added test case in axelar-core that reproduces the bug with the old code and passes with the fix:
- Creates a `KeygenStarted` event from actual devnet data
- Tests that it matches the `KeygenStarted` filter (✓)
- Tests that it does NOT match the `SigningStarted` filter (✓ after fix, ✗ before)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace gogo/protobuf with cosmos gogoproto in `events/filter.go` and update `go.mod` to depend on `github.com/cosmos/gogoproto` instead of `github.com/gogo/protobuf`.
> 
> - **Events**:
>   - Update `Filter[T]` in `events/filter.go` to use `github.com/cosmos/gogoproto/proto` for `MessageName`-based event type matching.
> - **Dependencies**:
>   - Add direct `github.com/cosmos/gogoproto v1.7.0`; remove direct `github.com/gogo/protobuf`.
>   - Adjust indirect deps accordingly in `go.mod`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdbf83438224a5a39f045ba0a35f5101d007c9c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->